### PR TITLE
CompatHelper: add new compat entry for PowerModels at version 0.19, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
+PowerModels = "0.19"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `PowerModels` package to `0.19`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.